### PR TITLE
Adding IntegerValue attribute to AssignQualification

### DIFF
--- a/lib/rturk/operations/assign_qualification.rb
+++ b/lib/rturk/operations/assign_qualification.rb
@@ -2,13 +2,14 @@
 
 module RTurk
   class AssignQualification < Operation
-    attr_accessor :qualification_type_id, :worker_id, :send_notification
+    attr_accessor :qualification_type_id, :worker_id, :send_notification, :integer_value
     require_params :qualification_type_id, :worker_id
 
     def to_params
       {'QualificationTypeId' => qualification_type_id,
        'WorkerId' => worker_id,
-       'SendNotification' => (!!send_notification).to_s}
+       'SendNotification' => (!!send_notification).to_s,
+       'IntegerValue' => integer_value}
     end
   end
 

--- a/spec/operations/assign_qualification_spec.rb
+++ b/spec/operations/assign_qualification_spec.rb
@@ -13,14 +13,16 @@ describe RTurk::AssignQualification do
 
   it "should successfully request the operation" do
     RTurk::Requester.should_receive(:request).once.with(
-      hash_including('Operation' => 'AssignQualification'))
+      hash_including('Operation' => 'AssignQualification', 'IntegerValue' => 80))
     RTurk::AssignQualification(:qualification_type_id => "123456789",
-                               :worker_id => "ABCDEF1234") rescue RTurk::InvalidRequest
+                               :worker_id => "ABCDEF1234",
+                               :integer_value => 80) rescue RTurk::InvalidRequest
   end
 
   it "should parse and return the result" do
     RTurk::AssignQualification(:qualification_type_id => "123456789",
-                               :worker_id => "ABCDEF1234").elements.should eql(
+                               :worker_id => "ABCDEF1234",
+                               :integer_value => 80).elements.should eql(
       {"AssignQualificationResult"=>{"Request"=>{"IsValid"=>"True"}}}
     )
   end


### PR DESCRIPTION
Allows you to specify a score (IntegerValue) when assigning a qualification to a worker.
