### PR TITLE
Added ServiceUnavailable error type for detecting/handling HTTP Service Unavailable errors

### DIFF
--- a/lib/rturk/errors.rb
+++ b/lib/rturk/errors.rb
@@ -2,4 +2,5 @@ module RTurk
   class RTurkError < StandardError; end;
   class MissingParameters < RTurkError; end;
   class InvalidRequest < RTurkError; end;
+  class ServiceUnavailable < RTurkError; end;
 end

--- a/lib/rturk/requester.rb
+++ b/lib/rturk/requester.rb
@@ -45,7 +45,12 @@ module RTurk
         end.join('&') # order doesn't matter for the actual request
 
         RTurk.logger.debug "Sending request:\n\t #{credentials.host}?#{querystring}"
-        RestClient.post(credentials.host, querystring)
+        begin
+          RestClient.post(credentials.host, querystring)
+        rescue RestClient::Exception => e
+          raise ServiceUnavailable if e.http_code == 503
+          raise
+        end
       end
 
       private

--- a/lib/rturk/utilities.rb
+++ b/lib/rturk/utilities.rb
@@ -29,6 +29,17 @@ module RTurk::Utilities
       tr("-", "_").
       downcase
   end
+  
+  # Executes the passed in block, retrying in cases of HTTP 503 Status Unvailable Errors
+  def self.retry_on_unavailable(delay=1)
+    begin
+      yield
+    rescue RTurk::ServiceUnavailable => e
+      RTurk.logger.debug "HTTP Error 503: Service Unavailable.  Retrying in #{delay} seconds."
+      sleep delay
+      retry
+    end
+  end
 
 end
 


### PR DESCRIPTION
Added new ServiceUnavailable < RTurkError to simplify the detection of HTTP 503 Service Unavailable Errors from AWS if the service is down or the Client IP is being throttled during a batch task.

This was helpful for me when doing batch processing and hitting the MTurk velocity limits.
http://aws.amazon.com/releasenotes/Amazon-Mechanical-Turk/1470

Let me know what you think.
