### PR TITLE
Adding support for operation SearchQualificationTypes

### DIFF
--- a/lib/rturk/operations/search_qualification_types.rb
+++ b/lib/rturk/operations/search_qualification_types.rb
@@ -1,0 +1,46 @@
+module RTurk
+  class SearchQualificationTypes < Operation
+    # You can call this operation without only required parameters and get an unsorted
+    # list or you can pass in a :sort_by => {:name => :ascending}
+    #
+    # You can sort by
+    #   :name
+    
+    attr_accessor :query, :sort_property, :sort_order, :page_size, :page_number, :sort_by, :must_be_requestable, :must_be_owned_by_caller
+    require_params :must_be_requestable
+    
+    SORT_BY = { :name => 'Name' }
+    SORT_ORDER = {:ascending => 'Ascending', :descending => 'Descending', :asc => 'Ascending', :desc => 'Descending'}
+    
+    def parse(xml)
+      RTurk::SearchQualificationTypesResponse.new(xml)
+    end
+    
+    def to_params
+      self.set_sort_by
+      params = {
+        'Query' => self.query,
+        'SortProperty' => self.sort_property,
+        'SortDirection' => self.sort_order,
+        'PageSize' => (self.page_size || 100),
+        'PageNumber' => (self.page_number || 1)
+      }
+      params['MustBeRequestable'] = self.must_be_requestable unless self.must_be_requestable.nil?
+      params['MustBeOwnedByCaller'] = self.must_be_owned_by_caller unless self.must_be_owned_by_caller.nil?
+      params
+    end
+    
+    def set_sort_by
+      if @sort_by
+        @sort_property = SORT_BY[@sort_by.keys.first]
+        @sort_order = SORT_ORDER[@sort_by.values.first]
+      end
+    end
+    
+  end
+
+  def self.SearchQualificationTypes(*args)
+    RTurk::SearchQualificationTypes.create(*args)
+  end
+
+end

--- a/lib/rturk/parsers/qualification_type_parser.rb
+++ b/lib/rturk/parsers/qualification_type_parser.rb
@@ -1,0 +1,28 @@
+# Parses a QualificationType object
+
+module RTurk
+  class QualificationTypeParser < RTurk::Parser
+    attr_reader :qualification_type_id, :creation_time, :name, :description,
+                :keywords, :status, :retry_delay_in_seconds, :is_requestable,
+                :test, :test_duration_in_seconds, :answer_key, :auto_granted,
+                :auto_granted_value
+
+    def initialize(qualifications_xml)
+      @xml_obj = qualifications_xml
+      map_content(@xml_obj,
+                  :qualification_type_id => 'QualificationTypeId',
+                  :creation_time => 'CreationTime',
+                  :name => 'Name',
+                  :description => 'Description',
+                  :keywords => 'Keywords',
+                  :status => 'QualificationTypeStatus',
+                  :retry_delay_in_seconds => 'RetryDelayInSeconds',
+                  :is_requestable => 'IsRequestable',
+                  :test => 'Test',
+                  :test_duration_in_seconds => 'TestDurationInSeconds',
+                  :answer_key => 'AnswerKey',
+                  :auto_granted => 'AutoGranted',
+                  :auto_granted_value => 'AutoGrantedValue')
+    end
+  end
+end

--- a/lib/rturk/parsers/responses/search_qualification_types_response.rb
+++ b/lib/rturk/parsers/responses/search_qualification_types_response.rb
@@ -75,7 +75,7 @@ module RTurk
     def qualification_types
       @qualification_types ||= []
       @xml.xpath('//QualificationType').each do |qualification_type_xml|
-        @qualification_types << QualificationParser.new(qualification_type_xml)
+        @qualification_types << QualificationTypeParser.new(qualification_type_xml)
       end
       @qualification_types
     end

--- a/lib/rturk/parsers/responses/search_qualification_types_response.rb
+++ b/lib/rturk/parsers/responses/search_qualification_types_response.rb
@@ -1,0 +1,85 @@
+module RTurk
+  # <SearchQualificationTypesResult>
+  #   <Request>
+  #     <IsValid>True</IsValid>
+  #   </Request>
+  #   <NumResults>10</NumResults>
+  #   <TotalNumResults>5813</TotalNumResults>
+  #   <QualificationType>
+  #     <QualificationTypeId>WKAZMYZDCYCZP412TZEZ</QualificationTypeId>
+  #     <CreationTime>2009-05-17T10:05:15Z</CreationTime>
+  #     <Name> WebReviews Qualification Master Test</Name>
+  #     <Description>
+  #       This qualification will allow you to earn more on the WebReviews HITs.
+  #     </Description>
+  #     <Keywords>WebReviews, webreviews, web reviews</Keywords>
+  #     <QualificationTypeStatus>Active</QualificationTypeStatus>
+  #     <Test>
+  #       <QuestionForm xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionForm.xsd">
+  #         <Overview>
+  #         <Title>WebReviews Survey</Title>
+  #         <Text>
+  #           After you have filled out this survey you will be assigned one or more qualifications...
+  #         </Text>
+  #         </Overview>
+  #         <Question>
+  #           <QuestionIdentifier>age</QuestionIdentifier>
+  #           <DisplayName>What is your age?</DisplayName>
+  #           <IsRequired>true</IsRequired>
+  #           <QuestionContent>
+  #             <Text>
+  #               Please choose the age group you belong to.
+  #             </Text>
+  #           </QuestionContent>
+  #           <AnswerSpecification>
+  #             <SelectionAnswer>
+  #               <StyleSuggestion>radiobutton</StyleSuggestion>
+  #               <Selections>
+  #                 <Selection>
+  #                   <SelectionIdentifier>0018</SelectionIdentifier>
+  #                   <Text>-18</Text>
+  #                 </Selection>
+  #                 <Selection>
+  #                   <SelectionIdentifier>5160</SelectionIdentifier>
+  #                   <Text>51-60</Text>
+  #                 </Selection>
+  #                 <Selection>
+  #                   <SelectionIdentifier>6000</SelectionIdentifier>
+  #                   <Text>60+</Text>
+  #                 </Selection>
+  #               </Selections>  
+  #             </SelectionAnswer>
+  #           </AnswerSpecification>
+  #         </Question> 
+  #       </QuestionForm>
+  #     </Test>
+  #     <TestDurationInSeconds>1200</TestDurationInSeconds>
+  #   </QualificationType>
+  #</SearchQualificationTypesResult>
+  
+  class SearchQualificationTypesResponse < Response
+    
+    attr_reader :num_results, :total_num_results, :page_number
+
+    def initialize(response)
+      @raw_xml = response.body
+      @xml = Nokogiri::XML(@raw_xml)
+      raise_errors
+      map_content(@xml.xpath('//SearchQualificationTypesResult'),
+        :num_results => 'NumResults',
+        :total_num_results => 'TotalNumResults',
+        :page_number => 'PageNumber'
+      )
+    end
+    
+    def qualification_types
+      @qualification_types ||= []
+      @xml.xpath('//QualificationType').each do |qualification_type_xml|
+        @qualification_types << QualificationParser.new(qualification_type_xml)
+      end
+      @qualification_types
+    end
+
+  end
+  
+end

--- a/spec/fake_responses/search_qualification_types.xml
+++ b/spec/fake_responses/search_qualification_types.xml
@@ -1,0 +1,58 @@
+<SearchQualificationTypesResult>
+  <Request>
+    <IsValid>True</IsValid>
+  </Request>
+  <NumResults>1</NumResults>
+  <TotalNumResults>1</TotalNumResults>
+  <PageNumber>1</PageNumber>
+  <QualificationType>
+    <QualificationTypeId>WKAZMYZDCYCZP412TZEZ</QualificationTypeId>
+    <CreationTime>2009-05-17T10:05:15Z</CreationTime>
+    <Name> WebReviews Qualification Master Test</Name>
+    <Description>
+    This qualification will allow you to earn more on the WebReviews HITs.
+    </Description>
+    <Keywords>WebReviews, webreviews, web reviews</Keywords>
+    <QualificationTypeStatus>Active</QualificationTypeStatus>
+      <Test>
+        <QuestionForm xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionForm.xsd">
+          <Overview>
+          <Title>WebReviews Survey</Title>
+          <Text>
+          After you have filled out this survey you will be assigned one or more qualifications...
+          </Text>
+        </Overview>
+        <Question>
+          <QuestionIdentifier>age</QuestionIdentifier>
+          <DisplayName>What is your age?</DisplayName>
+          <IsRequired>true</IsRequired>
+          <QuestionContent>
+            <Text>
+            Please choose the age group you belong to.
+            </Text>
+          </QuestionContent>
+          <AnswerSpecification>
+    		<SelectionAnswer>
+    		  <StyleSuggestion>radiobutton</StyleSuggestion>
+    		  <Selections>
+    		    <Selection>
+    		      <SelectionIdentifier>0018</SelectionIdentifier>
+    		      <Text>-18</Text>
+    		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>5160</SelectionIdentifier>
+  		      <Text>51-60</Text>
+  		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>6000</SelectionIdentifier>
+  		      <Text>60+</Text>
+  		    </Selection>
+  		  </Selections>  
+  	    </SelectionAnswer>
+         </AnswerSpecification>
+      </Question> 
+    </QuestionForm>
+    </Test>
+    <TestDurationInSeconds>1200</TestDurationInSeconds>
+  </QualificationType>
+</SearchQualificationTypesResult>

--- a/spec/operations/search_qualification_types_spec.rb
+++ b/spec/operations/search_qualification_types_spec.rb
@@ -1,0 +1,27 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe RTurk::SearchQualificationTypes do
+  before(:all) do
+    aws = YAML.load(File.open(File.join(SPEC_ROOT, 'mturk.yml')))
+    RTurk.setup(aws['AWSAccessKeyId'], aws['AWSAccessKey'], :sandbox => true)
+    faker('search_qualification_types', :operation => 'SearchQualificationTypes')
+  end
+
+  it "should ensure required params" do
+    lambda{RTurk::SearchQualificationTypes()}.should raise_error RTurk::MissingParameters
+  end
+
+  it "should successfully request the operation" do
+    RTurk::Requester.should_receive(:request).once.with(
+      hash_including('Operation' => 'SearchQualificationTypes'))
+    RTurk::SearchQualificationTypes({ :must_be_requestable => true }) rescue RTurk::InvalidRequest
+  end
+
+  it "should parse and return the result" do
+    response = RTurk::SearchQualificationTypes({ :must_be_requestable => true })
+    response.num_results.should eql(1)
+    qualification_types = response.qualification_types
+    qualification_types.size.should eql(1)
+    qualification_types.first.qualification_type_id.should eql('WKAZMYZDCYCZP412TZEZ')
+  end
+end

--- a/spec/operations/search_qualification_types_spec.rb
+++ b/spec/operations/search_qualification_types_spec.rb
@@ -23,5 +23,7 @@ describe RTurk::SearchQualificationTypes do
     qualification_types = response.qualification_types
     qualification_types.size.should eql(1)
     qualification_types.first.qualification_type_id.should eql('WKAZMYZDCYCZP412TZEZ')
+    qualification_types.first.name.should eql('WebReviews Qualification Master Test')
+    qualification_types.first.keywords.should eql('WebReviews, webreviews, web reviews')
   end
 end

--- a/spec/parsers/qualification_parser.rb
+++ b/spec/parsers/qualification_parser.rb
@@ -1,0 +1,67 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+
+describe RTurk::QualificationParser do
+  
+  before(:all) do
+    @qualification_xml = <<-XML
+<QualificationType>
+    <QualificationTypeId>WKAZMYZDCYCZP412TZEZ</QualificationTypeId>
+    <CreationTime>2009-05-17T10:05:15Z</CreationTime>
+    <Name> WebReviews Qualification Master Test</Name>
+    <Description>
+    This qualification will allow you to earn more on the WebReviews HITs.
+    </Description>
+    <Keywords>WebReviews, webreviews, web reviews</Keywords>
+    <QualificationTypeStatus>Active</QualificationTypeStatus>
+      <Test>
+        <QuestionForm xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionForm.xsd">
+          <Overview>
+          <Title>WebReviews Survey</Title>
+          <Text>
+          After you have filled out this survey you will be assigned one or more qualifications...
+          </Text>
+        </Overview>
+        <Question>
+          <QuestionIdentifier>age</QuestionIdentifier>
+          <DisplayName>What is your age?</DisplayName>
+          <IsRequired>true</IsRequired>
+          <QuestionContent>
+            <Text>
+            Please choose the age group you belong to.
+            </Text>
+          </QuestionContent>
+          <AnswerSpecification>
+    		<SelectionAnswer>
+    		  <StyleSuggestion>radiobutton</StyleSuggestion>
+    		  <Selections>
+    		    <Selection>
+    		      <SelectionIdentifier>0018</SelectionIdentifier>
+    		      <Text>-18</Text>
+    		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>5160</SelectionIdentifier>
+  		      <Text>51-60</Text>
+  		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>6000</SelectionIdentifier>
+  		      <Text>60+</Text>
+  		    </Selection>
+  		  </Selections>  
+  	    </SelectionAnswer>
+         </AnswerSpecification>
+      </Question> 
+    </QuestionForm>
+    </Test>
+    <TestDurationInSeconds>1200</TestDurationInSeconds>
+  </QualificationType>
+      XML
+    @qualification_xml = Nokogiri::XML(@qualification_xml)
+    @qualification = RTurk::QualificationParser.new(@qualification_xml.children)
+  end
+  
+  it "should parse an answer" do
+    @qualification.qualification_type_id.should eql('WKAZMYZDCYCZP412TZEZ')
+    @qualification.status.should eql('Active')
+  end
+end

--- a/spec/parsers/qualification_parser.rb
+++ b/spec/parsers/qualification_parser.rb
@@ -5,63 +5,19 @@ describe RTurk::QualificationParser do
   
   before(:all) do
     @qualification_xml = <<-XML
-<QualificationType>
-    <QualificationTypeId>WKAZMYZDCYCZP412TZEZ</QualificationTypeId>
-    <CreationTime>2009-05-17T10:05:15Z</CreationTime>
-    <Name> WebReviews Qualification Master Test</Name>
-    <Description>
-    This qualification will allow you to earn more on the WebReviews HITs.
-    </Description>
-    <Keywords>WebReviews, webreviews, web reviews</Keywords>
-    <QualificationTypeStatus>Active</QualificationTypeStatus>
-      <Test>
-        <QuestionForm xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionForm.xsd">
-          <Overview>
-          <Title>WebReviews Survey</Title>
-          <Text>
-          After you have filled out this survey you will be assigned one or more qualifications...
-          </Text>
-        </Overview>
-        <Question>
-          <QuestionIdentifier>age</QuestionIdentifier>
-          <DisplayName>What is your age?</DisplayName>
-          <IsRequired>true</IsRequired>
-          <QuestionContent>
-            <Text>
-            Please choose the age group you belong to.
-            </Text>
-          </QuestionContent>
-          <AnswerSpecification>
-    		<SelectionAnswer>
-    		  <StyleSuggestion>radiobutton</StyleSuggestion>
-    		  <Selections>
-    		    <Selection>
-    		      <SelectionIdentifier>0018</SelectionIdentifier>
-    		      <Text>-18</Text>
-    		    </Selection>
-  		    <Selection>
-  		      <SelectionIdentifier>5160</SelectionIdentifier>
-  		      <Text>51-60</Text>
-  		    </Selection>
-  		    <Selection>
-  		      <SelectionIdentifier>6000</SelectionIdentifier>
-  		      <Text>60+</Text>
-  		    </Selection>
-  		  </Selections>  
-  	    </SelectionAnswer>
-         </AnswerSpecification>
-      </Question> 
-    </QuestionForm>
-    </Test>
-    <TestDurationInSeconds>1200</TestDurationInSeconds>
-  </QualificationType>
+<Qualification>
+  <QualificationTypeId>789RVWYBAZW00EXAMPLE</QualificationTypeId>
+  <SubjectId>AZ3456EXAMPLE</SubjectId>
+  <GrantTime>2005-01-31T23:59:59Z</GrantTime>
+  <IntegerValue>95</IntegerValue>
+</Qualification>
       XML
     @qualification_xml = Nokogiri::XML(@qualification_xml)
     @qualification = RTurk::QualificationParser.new(@qualification_xml.children)
   end
   
   it "should parse an answer" do
-    @qualification.qualification_type_id.should eql('WKAZMYZDCYCZP412TZEZ')
-    @qualification.status.should eql('Active')
+    @qualification.qualification_type_id.should eql('789RVWYBAZW00EXAMPLE')
+    @qualification.subject_id.should eql('AZ3456EXAMPLE')
   end
 end

--- a/spec/parsers/qualification_type_parser_spec.rb
+++ b/spec/parsers/qualification_type_parser_spec.rb
@@ -1,0 +1,69 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+
+describe RTurk::QualificationTypeParser do
+  
+  before(:all) do
+    @qualification_type_xml = <<-XML
+<QualificationType>
+    <QualificationTypeId>WKAZMYZDCYCZP412TZEZ</QualificationTypeId>
+    <CreationTime>2009-05-17T10:05:15Z</CreationTime>
+    <Name> WebReviews Qualification Master Test</Name>
+    <Description>
+    This qualification will allow you to earn more on the WebReviews HITs.
+    </Description>
+    <Keywords>WebReviews, webreviews, web reviews</Keywords>
+    <QualificationTypeStatus>Active</QualificationTypeStatus>
+      <Test>
+        <QuestionForm xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionForm.xsd">
+          <Overview>
+          <Title>WebReviews Survey</Title>
+          <Text>
+          After you have filled out this survey you will be assigned one or more qualifications...
+          </Text>
+        </Overview>
+        <Question>
+          <QuestionIdentifier>age</QuestionIdentifier>
+          <DisplayName>What is your age?</DisplayName>
+          <IsRequired>true</IsRequired>
+          <QuestionContent>
+            <Text>
+            Please choose the age group you belong to.
+            </Text>
+          </QuestionContent>
+          <AnswerSpecification>
+    		<SelectionAnswer>
+    		  <StyleSuggestion>radiobutton</StyleSuggestion>
+    		  <Selections>
+    		    <Selection>
+    		      <SelectionIdentifier>0018</SelectionIdentifier>
+    		      <Text>-18</Text>
+    		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>5160</SelectionIdentifier>
+  		      <Text>51-60</Text>
+  		    </Selection>
+  		    <Selection>
+  		      <SelectionIdentifier>6000</SelectionIdentifier>
+  		      <Text>60+</Text>
+  		    </Selection>
+  		  </Selections>  
+  	    </SelectionAnswer>
+         </AnswerSpecification>
+      </Question> 
+    </QuestionForm>
+    </Test>
+    <TestDurationInSeconds>1200</TestDurationInSeconds>
+  </QualificationType>
+      XML
+    @qualification_type_xml = Nokogiri::XML(@qualification_type_xml)
+    @qualification_type = RTurk::QualificationTypeParser.new(@qualification_type_xml.children)
+  end
+  
+  it "should parse an answer" do
+    @qualification_type.qualification_type_id.should eql('WKAZMYZDCYCZP412TZEZ')
+    @qualification_type.status.should eql('Active')
+    @qualification_type.name.should eql('WebReviews Qualification Master Test')
+    @qualification_type.keywords.should eql('WebReviews, webreviews, web reviews')
+  end
+end


### PR DESCRIPTION
Adding support for operation SearchQualificationTypes

Just followed the pattern of previous operation additions, and added basic tests corresponding to the faker XML.
