### PR TITLE
Change/fix memoization on hit assignments

### DIFF
--- a/lib/rturk/adapters/hit.rb
+++ b/lib/rturk/adapters/hit.rb
@@ -62,7 +62,9 @@ module RTurk
 
     # memoing
     def assignments(options={})
-      @assignments ||= begin
+      @assignments ||= {}
+
+      @assignments[options] ||= begin
         assignments_options = options.update(:hit_id => self.id)
         
         RTurk::GetAssignmentsForHIT(assignments_options).assignments.inject([]) do |arr, assignment|


### PR DESCRIPTION
Sorry this isn't represented with a test, more or a less a hotfix.

The problem was that calling `.assigments(status: "Approved")` on a Hit object would memoize the approved ones. But when you called `.assignments(status: "Rejected")` it would return assignments that were approved because of the or equals.

This fixes that problem that I introduced. My bad!
