### PR TITLE
UTC Timestamps

### DIFF
--- a/lib/rturk/requester.rb
+++ b/lib/rturk/requester.rb
@@ -21,7 +21,7 @@ module RTurk
         base_params = {
           'Service'=>'AWSMechanicalTurkRequester',
           'AWSAccessKeyId' => credentials.access_key,
-          'Timestamp' => Time.now.iso8601,
+          'Timestamp' => Time.now.utc.iso8601,
           'Version' => RTurk::API_VERSION
         }
 


### PR DESCRIPTION
Requests from different timezones can be rejected if they are in an non UTC format. This ensures the timestamp sent to mechanical turk is formatted as such.

A [discussion](https://forums.aws.amazon.com/message.jspa?messageID=38767) on the AWS developer forums describes similar problems.
