### PR TITLE
added UpdateQualificationScore api

### DIFF
--- a/lib/rturk/operations/update_qualification_score.rb
+++ b/lib/rturk/operations/update_qualification_score.rb
@@ -1,0 +1,20 @@
+# Operation to update a qualification score
+
+module RTurk
+  class UpdateQualificationScore < Operation
+    attr_accessor :qualification_type_id, :qualification_type_score, :subject_id, :integer_value
+    require_params :qualification_type_id, :subject_id, :integer_value
+
+    def to_params
+      params = {
+        'QualificationTypeId' => qualification_type_id,
+        'SubjectId' => subject_id,
+        'IntegerValue'=> integer_value
+      }
+    end
+  end
+
+  def self.UpdateQualificationScore(*args)
+    RTurk::UpdateQualificationScore.create(*args)
+  end
+end

--- a/spec/fake_responses/update_qualification_score.xml
+++ b/spec/fake_responses/update_qualification_score.xml
@@ -1,0 +1,5 @@
+<UpdateQualificationScoreResult>
+  <Request>
+    <IsValid>True</IsValid>
+  </Request>
+</UpdateQualificationScoreResult>

--- a/spec/operations/update_qualification_score_spec.rb
+++ b/spec/operations/update_qualification_score_spec.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe RTurk::UpdateQualificationScore do
+  before(:all) do
+    aws = YAML.load(File.open(File.join(SPEC_ROOT, 'mturk.yml')))
+    RTurk.setup(aws['AWSAccessKeyId'], aws['AWSAccessKey'], :sandbox => true)
+    faker('update_qualification_score', :operation => 'UpdateQualificationScore')
+  end
+
+  it "should ensure required params" do
+    lambda{RTurk::UpdateQualificationScore()}.should raise_error RTurk::MissingParameters
+  end
+
+  it "should successfully request the operation" do
+    RTurk::Requester.should_receive(:request).once.with(
+      hash_including('Operation' => 'UpdateQualificationScore'))
+    RTurk::UpdateQualificationScore(:qualification_type_id => '789RVWYBAZW00EXAMPLE', 
+                                  :subject_id => "ABCDEF1234",
+                                  :integer_value => 80) rescue RTurk::InvalidRequest
+  end
+
+  it "should parse and return the result" do
+    response = RTurk::UpdateQualificationScore(:qualification_type_id => '789RVWYBAZW00EXAMPLE', 
+                                  :subject_id => "ABCDEF1234",
+                                  :integer_value => 80).elements.should eql(
+      {"UpdateQualificationScoreResult"=>{"Request"=>{"IsValid"=>"True"}}})
+  end
+end


### PR DESCRIPTION
I needed the ability to update the score of a qualification, but didn't see a way to do this w/ rturk, so I added the api to rturk. Tests pass and I did an actual test on my account.

Seems like a simple merge!?
