### PR TITLE
Fix SelectionIdentifier bug

### DIFF
--- a/lib/rturk/parsers/answer_parser.rb
+++ b/lib/rturk/parsers/answer_parser.rb
@@ -15,7 +15,7 @@ module RTurk
           if child.name == 'QuestionIdentifier'
             key = child.inner_text
           elsif child.name == 'SelectionIdentifier'
-            if answer.children.size = 1
+            if answer.children.length == 1
               value = child.inner_text
             else
               if value.nil?

--- a/lib/rturk/parsers/answer_parser.rb
+++ b/lib/rturk/parsers/answer_parser.rb
@@ -14,6 +14,16 @@ module RTurk
           next if child.blank?
           if child.name == 'QuestionIdentifier'
             key = child.inner_text
+          elsif child.name == 'SelectionIdentifier'
+            if answer.children.size = 1
+              value = child.inner_text
+            else
+              if value.nil?
+                value = Array(child.inner_text)
+              else
+                value << child.inner_text
+              end
+            end
           else
             value = child.inner_text
           end


### PR DESCRIPTION
Fixes bug with parsing SelectionIdentifier answers for question_form with 'checkbox' setting enabled. Parser returned only the last answer. Now returns value if there is only one answer or array if more.
