### PR TITLE
AnswerParser returns a list for multiple answers.

### DIFF
--- a/lib/rturk/parsers/answer_parser.rb
+++ b/lib/rturk/parsers/answer_parser.rb
@@ -9,16 +9,16 @@ module RTurk
       answer_hash = {}
       answers = answer_xml.xpath('//xmlns:Answer')
       answers.each do |answer|
-        key, value = nil, nil
+        key, values = nil, []
         answer.children.each do |child|
           next if child.blank?
           if child.name == 'QuestionIdentifier'
             key = child.inner_text
           else
-            value = child.inner_text
+            values << child.inner_text
           end
         end
-        answer_hash[key] = value
+        answer_hash[key] = values.count==1 ? values[0] : values
       end
       answer_hash
     end

--- a/spec/parsers/answer_parser_spec.rb
+++ b/spec/parsers/answer_parser_spec.rb
@@ -21,16 +21,44 @@ describe RTurk::AnswerParser do
 &lt;/Answer&gt;
 &lt;/QuestionFormAnswers&gt;
 XML
+
+    @multiple_answer = <<-XML
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;QuestionFormAnswers xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/QuestionFormAnswers.xsd"&gt;
+&lt;Answer&gt;
+&lt;QuestionIdentifier&gt;tweet&#91;content&#93;&lt;/QuestionIdentifier&gt;
+&lt;SelectionIdentifier&gt;Relevant&lt;/SelectionIdentifier&gt;
+&lt;SelectionIdentifier&gt;Funny&lt;/SelectionIdentifier&gt;
+&lt;/Answer&gt;
+&lt;Answer&gt;
+&lt;QuestionIdentifier&gt;tweet&#91;time&#93;&lt;/QuestionIdentifier&gt;
+&lt;FreeText&gt;12345678&lt;/FreeText&gt;
+&lt;/Answer&gt;
+&lt;Answer&gt;
+&lt;QuestionIdentifier&gt;Submit&lt;/QuestionIdentifier&gt;
+&lt;FreeText&gt;Submit&lt;/FreeText&gt;
+&lt;/Answer&gt;
+&lt;/QuestionFormAnswers&gt;
+XML
   end
   
   it "should parse a answer" do
     RTurk::AnswerParser.parse(@answer).to_hash.should == {"Submit"=>"Submit", "tweet[content]"=>"This is my tweet!", "tweet[time]" => "12345678"}
   end
 
-	it "should parse an answer into a param hash" do
-		hash = RTurk::AnswerParser.parse(@answer).to_hash
-		RTurk::Parser.new.normalize_nested_params(hash).should == {"Submit"=>"Submit", "tweet"=> {"content" => "This is my tweet!", "time" => "12345678"}}
-	end
+  it "should parse an answer into a param hash" do
+    hash = RTurk::AnswerParser.parse(@answer).to_hash
+    RTurk::Parser.new.normalize_nested_params(hash).should == {"Submit"=>"Submit", "tweet"=> {"content" => "This is my tweet!", "time" => "12345678"}}
+  end
 
-  
+  it "should parse multiple answers" do
+    RTurk::AnswerParser.parse(@multiple_answer).to_hash.should == {"Submit"=>"Submit", "tweet[content]"=>["Relevant", "Funny"], "tweet[time]" => "12345678"}
+  end
+
+  it "should parse multiple answers into a param hash" do
+    hash = RTurk::AnswerParser.parse(@multiple_answer).to_hash
+    RTurk::Parser.new.normalize_nested_params(hash).should == {"Submit"=>"Submit", "tweet"=> {"content" => ["Relevant", "Funny"], "time" => "12345678"}}
+  end
+
+
 end


### PR DESCRIPTION
Modifies AnswerParseR to record a list of answers when there are multiple children (besides  `QuestionIdentifier`) in the answer tag
